### PR TITLE
Changed .selfloop_edges to align with networkx 2.4

### DIFF
--- a/metaknowledge/graphHelpers.py
+++ b/metaknowledge/graphHelpers.py
@@ -803,11 +803,11 @@ def graphStats(G, stats = ('nodes', 'edges', 'isolates', 'loops', 'density', 'tr
     if 'loops' in stats:
         if makeString:
             if sentenceString:
-                stsData.append("{:G} self loops".format(len(list(G.selfloop_edges()))))
+                stsData.append("{:G} self loops".format(len(list(nx.selfloop_edges(G)))))
             else:
-                stsData.append("Self loops: {:G}".format(len(list(G.selfloop_edges()))))
+                stsData.append("Self loops: {:G}".format(len(list(nx.selfloop_edges(G)))))
         else:
-            stsData['loops'] = len(list(G.selfloop_edges()))
+            stsData['loops'] = len(list(nx.selfloop_edges(G)))
     if 'density' in stats:
         if makeString:
             if sentenceString:


### PR DESCRIPTION
The Graph Object method G.selfloop_edges has been removed in networkx 2.4 (see the [release notes](https://networkx.github.io/documentation/stable/release/release_2.4.html#deprecations)). Changed the method to nx.selfloop_edges(G) to align with networkx 2.4.